### PR TITLE
Update setup.py version flag

### DIFF
--- a/pyflow/setup.py
+++ b/pyflow/setup.py
@@ -34,7 +34,7 @@ from distutils.core import setup
 
 setup(
       name='pyFlow',
-      version='${VERSION}',
+      version='2.0.0',
       description='A lightweight parallel task engine',
       author='Chris Saunders',
       author_email='csaunders@illumina.com',


### PR DESCRIPTION
Pip cares about PEP validation and current version flag throws an install error because the wheel gets named pyFlow-_VERSION_-py3-none-any.whl